### PR TITLE
Allow multiple users and focus on repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,16 @@ what-is-happening --user jedcn,banderson
 ```
 
 Results will be written to `jedcn-banderson.html`.
+
+### Focused Repositories
+
+If you know that a "team" of people focus their work on specific repos, you can
+ignore work those team members contribute to additional repositories with
+`--focus-on-repos`:
+
+```
+what-is-happening --user jedcn,banderson --focus-on-repos jedcn/NicknameGenerator,banderson/Inception
+```
+
+This would only report on activity associated with `jedcn/NicknameGenerator`
+and `banderson/Inception`.

--- a/README.md
+++ b/README.md
@@ -41,3 +41,14 @@ If you need an Access Token, visit your Github Enterprise:
 
 The Access Token does not need any particular powers-- it should be created
 w/ the no additional permissions.
+
+### Multiple Users
+
+You can understand what a "team" of people have been up to by passing
+comma-separated values for `--user`:
+
+```
+what-is-happening --user jedcn,banderson
+```
+
+Results will be written to `jedcn-banderson.html`.

--- a/bin/what-is-happening
+++ b/bin/what-is-happening
@@ -2,6 +2,7 @@
 
 const argv = require('minimist')(process.argv.slice(2));
 const user = argv.user;
+const focusOnRepos = argv['focus-on-repos'] ? argv['focus-on-repos'].split(',') : [];
 
 const initOctokit = require('../lib/github/client/initOctokit');
 const fetchUserEvents = require('../lib/github/core/fetchUserEvents');
@@ -10,7 +11,7 @@ const createRenderData = require('../lib/github/core/createRenderData');
 const renderContentFromEvents = require('../lib/github/render/renderContentFromEvents');
 const writeContentToFile = require('../lib/github/render/writeContentToFile');
 const mergeListsOfEventData = require('../lib/github/core/mergeListsOfEventData');
-
+const removeEventsNotInRepos = require('../lib/github/core/removeEventsNotInRepos');
 const host = argv.host || 'api.github.com';
 
 const buildOctokit = (host, argv) => {
@@ -37,7 +38,8 @@ const users = user.split(',');
 
 fetchAllUserEvents({ host, argv, users, beginning })
   .then((listOfListsOfEventData) => {
-    const userEventsData = mergeListsOfEventData(listOfListsOfEventData);
+    let userEventsData = mergeListsOfEventData(listOfListsOfEventData);
+    userEventsData = removeEventsNotInRepos(userEventsData, focusOnRepos);
     const events = buildEvents({ host, userEventsData });
     const begin = beginning;
     const end = new Date();

--- a/bin/what-is-happening
+++ b/bin/what-is-happening
@@ -9,23 +9,35 @@ const buildEvents = require('../lib/github/core/buildEvents');
 const createRenderData = require('../lib/github/core/createRenderData');
 const renderContentFromEvents = require('../lib/github/render/renderContentFromEvents');
 const writeContentToFile = require('../lib/github/render/writeContentToFile');
+const mergeListsOfEventData = require('../lib/github/core/mergeListsOfEventData');
+
 const host = argv.host || 'api.github.com';
 
-let octokit;
-const usingGithubEnterprise = host !== 'api.github.com';
-if (usingGithubEnterprise) {
-  const pathPrefix = argv['path-prefix'] || 'api/v3';
-  const accessToken = process.env.ACCESS_TOKEN;
-  octokit = initOctokit({ host, pathPrefix, accessToken });
-} else {
-  octokit = initOctokit({ host });
-}
+const buildOctokit = (host, argv) => {
+  const usingGithubEnterprise = host !== 'api.github.com';
+  if (usingGithubEnterprise) {
+    const pathPrefix = argv['path-prefix'] || 'api/v3';
+    const accessToken = process.env.ACCESS_TOKEN;
+    return initOctokit({ host, pathPrefix, accessToken });
+  } else {
+    return initOctokit({ host });
+  }
+};
 
 const { subDays } = require('date-fns');
 const beginning = subDays(new Date(), 7);
 
-fetchUserEvents({ octokit, user, beginning })
-  .then((userEventsData) => {
+const fetchAllUserEvents = ({ host, argv, users, beginning }) => {
+  const octokit = buildOctokit(host, argv);
+  const promises = users.map((user) => fetchUserEvents({ octokit, user, beginning }));
+  return Promise.all(promises);
+};
+
+const users = user.split(',');
+
+fetchAllUserEvents({ host, argv, users, beginning })
+  .then((listOfListsOfEventData) => {
+    const userEventsData = mergeListsOfEventData(listOfListsOfEventData);
     const events = buildEvents({ host, userEventsData });
     const begin = beginning;
     const end = new Date();
@@ -34,10 +46,10 @@ fetchUserEvents({ octokit, user, beginning })
       end,
       events,
       host,
-      user
+      users
     });
     const renderedContent = renderContentFromEvents(renderData);
-    const outputFile = `${user}.html`;
+    const outputFile = `${users.join('-')}.html`;
     writeContentToFile(renderedContent, outputFile);
     console.log(`Results written to ${outputFile}`);
   }).catch(err => {

--- a/lib/github/core/HtmlWrapper.js
+++ b/lib/github/core/HtmlWrapper.js
@@ -1,7 +1,7 @@
 const renderStringWithData = require('./renderHelpers').renderStringWithData;
 const EventTemplates = require('./EventTemplates');
 const EventTypes = require('./EventTypes');
-const { hrefForRepo, hrefForBranch, link } = require('./linkUtils');
+const { link } = require('./linkUtils');
 
 class HtmlWrapper {
 

--- a/lib/github/core/createRenderData.js
+++ b/lib/github/core/createRenderData.js
@@ -4,7 +4,7 @@ const OpenPullRequestSummary = require('../summaries/OpenPullRequestSummary');
 const MergedPullRequestSummary = require('../summaries/MergedPullRequestSummary');
 const PullRequestCommentSummary = require('../summaries/PullRequestCommentSummary');
 
-const createRenderData = ({ begin, end, events, host, summaryItems, user }) => {
+const createRenderData = ({ begin, end, events, host, users }) => {
   const server = host === 'api.github.com' ? 'github.com' : host;
   const eventsWithHtmlAsJSON = events.map((event) => new HtmlWrapper(event).toJSON()).toJSON();
   const summariesAsJSON = [
@@ -17,7 +17,7 @@ const createRenderData = ({ begin, end, events, host, summaryItems, user }) => {
     end,
     userEvents: eventsWithHtmlAsJSON,
     summaries: summariesAsJSON,
-    user
+    users
   }
 };
 

--- a/lib/github/core/mergeListsOfEventData.js
+++ b/lib/github/core/mergeListsOfEventData.js
@@ -6,9 +6,6 @@ const mergeListsOfEventData = (listOfListsOfEventData) => {
     return acc.concat(list);
   }, List());
   return allEntriesMergedTogether.sort((userEventA, userEventB) => {
-    // const createdAtA = new Date(userEventA.get('created_at'));
-    // const createdAtB = new Date(userEventB.get('created_at'));
-    // return compareDesc(createdAtA, createdAtB);
     return compareDesc(userEventA.get('created_at'), userEventB.get('created_at'));
   });
 };

--- a/lib/github/core/mergeListsOfEventData.js
+++ b/lib/github/core/mergeListsOfEventData.js
@@ -1,0 +1,16 @@
+const { compareDesc } = require('date-fns');
+const { List } = require('immutable');
+
+const mergeListsOfEventData = (listOfListsOfEventData) => {
+  const allEntriesMergedTogether = listOfListsOfEventData.reduce((acc, list) => {
+    return acc.concat(list);
+  }, List());
+  return allEntriesMergedTogether.sort((userEventA, userEventB) => {
+    // const createdAtA = new Date(userEventA.get('created_at'));
+    // const createdAtB = new Date(userEventB.get('created_at'));
+    // return compareDesc(createdAtA, createdAtB);
+    return compareDesc(userEventA.get('created_at'), userEventB.get('created_at'));
+  });
+};
+
+module.exports = mergeListsOfEventData;

--- a/lib/github/core/removeEventsNotInRepos.js
+++ b/lib/github/core/removeEventsNotInRepos.js
@@ -1,0 +1,11 @@
+const removeEventsNotInRepos = (userEventsData, focusOnRepos) => {
+  if (focusOnRepos.length === 0) {
+    return userEventsData;
+  }
+  return userEventsData.filter((userEventMap) => {
+    const repoNameForEvent = userEventMap.getIn(['repo', 'name']);
+    return focusOnRepos.includes(repoNameForEvent);
+  });
+};
+
+module.exports = removeEventsNotInRepos;

--- a/lib/github/render/renderContentFromEvents.js
+++ b/lib/github/render/renderContentFromEvents.js
@@ -1,8 +1,8 @@
 const renderTemplateWithData = require('../core/renderHelpers').renderTemplateWithData;
 const describeTime = require('../core/describeTime');
 
-const renderContentFromEvents = ({ begin, end, user, userEvents, summaries }) => {
-  const title = `${user} Activity`;
+const renderContentFromEvents = ({ begin, end, users, userEvents, summaries }) => {
+  const title = `${users.join(', ')} Activity`;
   const renderData = {
     begin: describeTime(begin),
     end: describeTime(end),

--- a/lib/github/summaries/IssueCommentSummary.js
+++ b/lib/github/summaries/IssueCommentSummary.js
@@ -32,7 +32,6 @@ class IssueCommentSummary extends BaseSummary {
   }
 
   getSummaryItems() {
-    const { server } = this.config;
     return this.getFilteredEvents().map((event) => {
       return {
         context: link(event.getPullRequestHref(), event.getTitle()),

--- a/lib/github/summaries/PullRequestCommentSummary.js
+++ b/lib/github/summaries/PullRequestCommentSummary.js
@@ -32,7 +32,6 @@ class PullRequestCommentSummary extends BaseSummary {
   }
 
   getSummaryItems() {
-    const { server } = this.config;
     return this.getFilteredEvents().map((event) => {
       return {
         context: link(event.getPullRequestHref(), event.getTitle()),


### PR DESCRIPTION
# Overview

This change provides support for two new command line flags:

* `--user` can now be a comma-separated list of users
* `--focus-on-repos` is a new option that can contain a comma-separated list of repositories

See the `README.md` changes for details.